### PR TITLE
Fix for UTF-8 strings

### DIFF
--- a/NexmoMessage.php
+++ b/NexmoMessage.php
@@ -63,13 +63,16 @@ class NexmoMessage {
 	 */
 	function sendText ( $to, $from, $message ) {
 	
-		if ( !is_numeric($from) ) {
-			//Must be UTF-8 Encoded if not a continuous number
-			$from = utf8_encode( $from );
+		// Making sure strings are UTF-8 encoded
+		if ( !is_numeric($from) && !mb_check_encoding($from, 'UTF-8') ) {
+			trigger_error('$from needs to be a valid UTF-8 encoded string');
+			return false;
 		}
-		
-		//Must be UTF-8 Encoded
-		$message = utf8_encode( $message );
+
+		if ( !mb_check_encoding($message, 'UTF-8') ) {
+			trigger_error('$message needs to be a valid UTF-8 encoded string');
+			return false;
+		}
 		
 		// Make sure $from is valid
 		$from = $this->validateOriginator($from);
@@ -118,11 +121,13 @@ class NexmoMessage {
 	 * Prepare new binary message.
 	 */
 	function pushWap ( $to, $from, $title, $url, $validity = 172800000 ) {
-		
-		//WAP Push title and URL must be UTF-8 Encoded
-		$title = utf8_encode ( $body );
-		$url = utf8_encode ( $udh );
 
+		// Making sure $title and $url are UTF-8 encoded
+		if ( !mb_check_encoding($title, 'UTF-8') || !mb_check_encoding($url, 'UTF-8') ) {
+			trigger_error('$title and $udh need to be valid UTF-8 encoded strings');
+			return false;
+		}
+		
 		// Make sure $from is valid
 		$from = $this->validateOriginator($from);
 

--- a/NexmoMessage.php
+++ b/NexmoMessage.php
@@ -74,6 +74,8 @@ class NexmoMessage {
 			return false;
 		}
 		
+		$containsUnicode = max(array_map('ord', str_split($message))) > 127;
+		
 		// Make sure $from is valid
 		$from = $this->validateOriginator($from);
 
@@ -85,7 +87,8 @@ class NexmoMessage {
 		$post = array(
 			'from' => $from,
 			'to' => $to,
-			'text' => $message
+			'text' => $message,
+			'type' => $containsUnicode ? 'unicode' : 'text'
 		);
 		return $this->sendRequest ( $post );
 		


### PR DESCRIPTION
`utf8_encode` converts an ISO-8859-1 encoded string to UTF-8. That does nothing for ASCII-only text and completely garbles actual UTF-8 encoded text. So far this library was not able to send "international" text, at best only the 256 ISO-8859-1 characters.

Fixing this by only _checking_ for UTF-8 validity without touching the string.
