### PR TITLE
Corrected mistyped errortext of displayOverview

### DIFF
--- a/NexmoMessage.php
+++ b/NexmoMessage.php
@@ -300,7 +300,7 @@ class NexmoMessage {
 			$tmp = array('id'=>'', 'status'=>0);
 
 			if ( $message->status != 0) {
-				$tmp['status'] = $message->errortex;
+				$tmp['status'] = $message->errortext;
 			} else {
 				$tmp['status'] = 'OK';
 				$tmp['id'] = $message->messageid;


### PR DESCRIPTION
Corrected the property errortext for error display in displayOverview.
Just in case your sending failed you get the actual error not a php error
